### PR TITLE
Updates nucleus dependency and fixes import statement for AFKManager

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,5 +27,5 @@ repositories {
 
 dependencies {
     compile 'org.spongepowered:spongeapi:7.2.0'
-    compile 'io.github.nucleuspowered:nucleus-api:1.14.4-S7.1'
+    compile 'io.github.nucleuspowered:nucleus-api:2.3.0'
 }

--- a/src/main/java/io/github/icohedron/sleepvote/AFKManager.java
+++ b/src/main/java/io/github/icohedron/sleepvote/AFKManager.java
@@ -1,6 +1,6 @@
 package io.github.icohedron.sleepvote;
 
-import io.github.nucleuspowered.nucleus.api.events.NucleusAFKEvent;
+import io.github.nucleuspowered.nucleus.api.module.afk.event.NucleusAFKEvent;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.filter.cause.First;


### PR DESCRIPTION
As of August, Nucleus has undergone a major new release version and with it they've changed the structure of their API, this was causing the plugin to crash on startup because it couldn't hook into their AFK events.

`Could not pass the event FMLInitializationEvent to an Event Listener!
Owning Mod/Plugin: sleepvote
Exception:
     java.lang.NoClassDefFoundError:
     io/github/nucleuspowered/nucleus/api/events/NucleusAFKEvent$ReturningFromAFK`

I've tested my changes and they both compile and fix the error, and AFK detection works as expected.